### PR TITLE
fix(#1999): Improve accessibility in DocSearch results

### DIFF
--- a/packages/dev/docs/src/Layout.js
+++ b/packages/dev/docs/src/Layout.js
@@ -342,7 +342,7 @@ function Nav({currentPageName, pages}) {
           </a>
         }
         <a href={isBlog ? '/index.html' : './index.html'} className={docStyles.homeBtn} id="nav-title-id">
-          <svg viewBox="0 0 30 26" fill="#E1251B" aria-label="Adobe">
+          <svg viewBox="0 0 30 26" fill="#E1251B" role="img" aria-label="Adobe">
             <polygon points="19,0 30,0 30,26" />
             <polygon points="11.1,0 0,0 0,26" />
             <polygon points="15,9.6 22.1,26 17.5,26 15.4,20.8 10.2,20.8" />

--- a/packages/dev/docs/src/docs.css
+++ b/packages/dev/docs/src/docs.css
@@ -587,6 +587,8 @@ h2.sectionHeader {
     left: 0;
   }
 
+  z-index: 1;
+
   & :global(.algolia-autocomplete .ds-dropdown-menu) {
     border-color: var(--spectrum-alias-border-color-dark, var(--spectrum-global-color-gray-400));
     border-radius: var(--spectrum-global-dimension-size-65);
@@ -635,6 +637,17 @@ h2.sectionHeader {
       background: var(--spectrum-global-color-gray-300);
     }
 
+    & :global(.ds-suggestion.ds-cursor .algolia-docsearch-suggestion--subcategory-column:before) {
+      background: var(--spectrum-alias-border-color-focus);
+      width: var(--spectrum-selectlist-border-size-key-focus);
+    }
+
+    & :global(.ds-suggestion.ds-cursor .algolia-docsearch-suggestion--content:before) {
+      background: var(--spectrum-alias-border-color-focus);
+      width: var(--spectrum-selectlist-border-size-key-focus);
+      left: calc(-1 * var(--spectrum-selectlist-border-size-key-focus));
+    }
+
     & :global(.ds-suggestion.ds-cursor .algolia-docsearch-suggestion:not(.suggestion-layout-simple) .algolia-docsearch-suggestion--content) {
       background-color: var(--spectrum-alias-background-color-hover-overlay);
     }
@@ -645,6 +658,26 @@ h2.sectionHeader {
 
     & :global(.algolia-docsearch-suggestion--title) {
       color: var(--spectrum-global-color-gray-800);
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .pageHeader {
+    & :global(.algolia-autocomplete) {
+      & :global(.algolia-docsearch-suggestion .algolia-docsearch-suggestion--subcategory-column) {
+        color: var(--spectrum-global-color-gray-700);
+        opacity: 1;
+      }
+
+      & :global(.algolia-docsearch-suggestion .algolia-docsearch-suggestion--subcategory-column:after) {
+        content: "|\00A0";
+      }
+
+      & :global(.ds-suggestion.ds-cursor .algolia-docsearch-suggestion .algolia-docsearch-suggestion--subcategory-column:after) {
+        color: var(--spectrum-alias-border-color-focus);
+        font-weight: bold;
+      }
     }
   }
 }


### PR DESCRIPTION
Update to #2016 to improve accessibility in DocSearch results so that they better implement the WAI-ARIA ComboBox design pattern.

- Fixes a few other docs issues identified with aXe DevTools.
- Fixes a couple console error messages with themeSwitcherButton and hamburgerButton.


Relates to #1999 and #2016

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [React Spectrum GitHub Issue 1999](https://github.com/adobe/react-spectrum/issues/1999).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. `yarn start:docs`
2. Open http://localhost:1234/
3. Start screen reader, like VoiceOver.
4. Navigate to Search combobox.
5. Enter some text to search.
6. Use arrow down/up to navigate through search terms in dropdown.
7. Verify that option items announce without double voicing redundant content when subcategory matches suggestion title.

## 🧢 Your Project:

Adobe/Accessibility

## Related issue:
https://github.com/algolia/docsearch/issues/1014
